### PR TITLE
deps: chakrashim enable JavaScript debugging

### DIFF
--- a/deps/chakrashim/chakrashim.gyp
+++ b/deps/chakrashim/chakrashim.gyp
@@ -2,6 +2,7 @@
   'variables': {
     'library_files': [
       'lib/chakra_shim.js',
+      'lib/chakra_debug.js'
     ],
   },
 
@@ -68,6 +69,8 @@
         'src/jsrtcontextcachedobj.inc',
         'src/jsrtcontextshim.cc',
         'src/jsrtcontextshim.h',
+        'src/jsrtdebug.cc',
+        'src/jsrtdebug.h',
         'src/jsrtisolateshim.cc',
         'src/jsrtisolateshim.h',
         'src/jsrtpromise.cc',

--- a/deps/chakrashim/include/v8-debug.h
+++ b/deps/chakrashim/include/v8-debug.h
@@ -26,11 +26,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
+
 #include <v8.h>
 
 namespace v8 {
 
-// NOT IMPLEMENTED
 class V8_EXPORT Debug {
  public:
   class ClientData {
@@ -47,24 +47,18 @@ class V8_EXPORT Debug {
   typedef void (*MessageHandler)(const Message& message);
 
   static void DebugBreak(Isolate *isolate = NULL) {}
-  static void SetDebugMessageDispatchHandler(
-    DebugMessageDispatchHandler handler, bool provide_locker = false) {}
-  static bool EnableAgent(
-    const char *name = NULL, int port = 0, bool wait_for_connection = false);
-  static void Dispose();
-  static void DisableAgent() {}
-  static bool IsAgentEnabled();
-  static void ProcessDebugMessages(Isolate* isolate) {}
-  static Local<Context> GetDebugContext(Isolate* isolate);
-  static void SetMessageHandler(Isolate* isolate, MessageHandler handler) {}
+  static void SetMessageHandler(Isolate* isolate, MessageHandler handler);
   static void SendCommand(Isolate* isolate,
                           const uint16_t* command, int length,
-                          ClientData* client_data = NULL) {
-  }
+                          ClientData* client_data = NULL);
   static MaybeLocal<Value> GetMirror(Local<Context> context,
                                      Handle<Value> obj) {
     return MaybeLocal<Value>();
   }
+  static void ProcessDebugMessages(Isolate* isolate) {}
+  static Local<Context> GetDebugContext(Isolate* isolate);
+
+  static void EnableDebug();
 };
 
 }  // namespace v8

--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -2279,7 +2279,6 @@ class V8_EXPORT StartupData {
 
 class V8_EXPORT V8 {
  public:
-  static void SetArrayBufferAllocator(ArrayBuffer::Allocator* allocator);
   static bool IsDead();
   static void SetFlagsFromString(const char* str, int length);
   static void SetFlagsFromCommandLine(

--- a/deps/chakrashim/lib/chakra_debug.js
+++ b/deps/chakrashim/lib/chakra_debug.js
@@ -1,0 +1,1287 @@
+// Copyright Microsoft. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the 'Software'), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and / or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+/* eslint-disable strict */
+(function(globalObject, keepAliveObject, traceDebugJson) {
+  var globalExecutionState;
+  var pendingMessages = [];
+
+  var Logger = (function() {
+    var logTypes = {
+      API: 1,
+      DebugJson: 2,
+      Error: 3
+    };
+
+    var enabledLogType = [];
+    enabledLogType[logTypes.API] = false; // For development purpose
+    enabledLogType[logTypes.DebugJson] = traceDebugJson === true;
+    enabledLogType[logTypes.Error] = true; // Always enabled
+
+    function logFunc(logType, argsArray) {
+      if (enabledLogType[logType]) {
+        var printStr = '';
+        for (var index in argsArray) {
+          var obj = argsArray[index];
+          if (obj != undefined) {
+            printStr += (typeof obj != 'string') ? JSON.stringify(obj) : obj;
+            printStr += ': ';
+          }
+        }
+        chakraDebug.log(printStr);
+      }
+    }
+
+    return {
+      LogAPI: function(msg, obj) {
+        logFunc(logTypes.API, arguments);
+      },
+      LogDebugJson: function(msg, obj) {
+        logFunc(logTypes.DebugJson, arguments);
+      },
+      LogError: function(msg, obj) {
+        logFunc(logTypes.Error, arguments);
+      }
+    };
+  })();
+
+  function CallHostFunctionNoLog(fn) {
+    var args = [].slice.call(arguments, 1);
+    var start = new Date();
+    var result = fn.apply(undefined, args);
+    var end = new Date();
+    Logger.LogAPI(`${fn.name}(${args}):${end - start}`);
+    return result;
+  }
+
+  function CallHostFunction(fn) {
+    var args = [].slice.call(arguments, 1);
+    var start = new Date();
+    var result = fn.apply(undefined, args);
+    var end = new Date();
+    Logger.LogAPI(`${fn.name}(${args}):${end - start}`, result);
+    return result;
+  }
+
+  if (!globalObject.Debug) {
+    globalObject.Debug = {};
+  }
+
+  var Debug = globalObject.Debug;
+
+  Debug.ScriptBreakPointType = {
+    ScriptId: 0,
+    ScriptName: 1,
+    ScriptRegExp: 2
+  };
+
+  Debug.setListener = function(fn) { };
+
+  Debug.setBreakPoint = function(func, line, column) {
+    Logger.LogAPI(`Debug.setBreakPoint(${func},${line},${column})`);
+    var funcInfo = CallHostFunction(chakraDebug.JsDiagGetFunctionPosition,
+                                     func);
+    var bpId = -1;
+
+    if (funcInfo.scriptId >= 0) {
+      var scriptObj = DebugManager.ScriptsManager.GetScript(funcInfo.scriptId);
+      var bpLine = funcInfo.firstStatementLine + line;
+      var bpColumn = funcInfo.firstStatementColumn + column;
+      var v8Breakpoint = new V8Breakpoint(Debug.ScriptBreakPointType.ScriptId,
+                              funcInfo.scriptId, scriptObj, bpLine, bpColumn);
+      if (v8Breakpoint.Set()) {
+        bpId = v8Breakpoint.Id();
+        DebugManager.BreakpointManager.AddBreakpoint(v8Breakpoint);
+      }
+    }
+
+    return bpId;
+  };
+
+  function AddChildrens(obj) {
+    if ('display' in obj) {
+      if (!('value' in obj) || !isFinite(obj['value']) ||
+        obj['value'] == null || obj['value'] == undefined) {
+        obj['value'] = obj['display'];
+      }
+      if (!('text' in obj)) {
+        obj['text'] = obj['display'];
+      }
+      if (!('className' in obj)) {
+        obj['className'] = obj['type'];
+      }
+    }
+
+    if ('className' in obj && obj['className'] == 'Object') {
+      obj.constructorFunction = {
+        'ref': globalExecutionState.GetObjectEvalHandle()
+      };
+      obj.protoObject = {
+        'ref': globalExecutionState.GetObjectProtoEvalHandle()
+      };
+      obj.prototypeObject = {
+        'ref': globalExecutionState.GetObjectPrototypeEvalHandle()
+      };
+    }
+
+    var PROPERTY_ATTRIBUTE_HAVE_CHILDRENS = 0x1;
+    //var PROPERTY_ATTRIBUTE_READ_ONLY_VALUE = 0x2;
+
+    if (('propertyAttributes' in obj) &&
+      ((obj['propertyAttributes'] & PROPERTY_ATTRIBUTE_HAVE_CHILDRENS) ==
+      PROPERTY_ATTRIBUTE_HAVE_CHILDRENS)) {
+      var objectHandle = obj['handle'];
+
+      var childProperties = CallHostFunction(chakraDebug.JsDiagGetProperties,
+        objectHandle, 0, 1000);
+
+      var propertiesArray = [];
+      ['properties', 'debuggerOnlyProperties'].forEach(
+        function(propertyCategory) {
+          childProperties[propertyCategory].map(function(property) {
+            propertiesArray.push({
+              'name': property['name'],
+              'propertyType': 0,
+              'ref': property['handle']
+            });
+          });
+        });
+      obj['properties'] = propertiesArray;
+    }
+  }
+
+  var DebugManager = (function() {
+    var _internalHandle = Number.MAX_SAFE_INTEGER;
+
+    function GetNextInternalHandle() {
+      return --_internalHandle;
+    }
+
+    var _nextResponseSeq = 0;
+
+    function Response(request) {
+      this.seq = _nextResponseSeq++;
+      this.type = 'response';
+      this.request_seq = request.seq;
+      this.command = request.command;
+      this.success = false;
+      this.running = globalExecutionState ? false : true;
+    }
+
+    var _nextEventSeq = 0;
+
+    function Event(eventName) {
+      this.seq = _nextEventSeq++;
+      this.type = 'event';
+      this.event = eventName;
+      this.success = true;
+      this.running = globalExecutionState ? false : true;
+    }
+
+    var Utility = {
+      MakeResponse: function(request) {
+        return new Response(request);
+      },
+      MakeEvent: function(eventName) {
+        return new Event(eventName);
+      },
+      CreateScopeAndRef: function(scopeType, propertiesArray, index,
+                                    frameIndex) {
+        var scopeRef = GetNextInternalHandle();
+        var scopeAndRef = {};
+        scopeAndRef.scope = {
+          'type': scopeType,
+          'index': index,
+          'frameIndex': frameIndex,
+          'object': {
+            'ref': scopeRef
+          }
+        };
+        var properties = [];
+        propertiesArray.map(function(property) {
+          properties.push({
+            'name': property['name'],
+            'propertyType': 0,
+            'ref': property['handle']
+          });
+        });
+        scopeAndRef.ref = {
+          'handle': scopeRef,
+          'type': 'object',
+          'className': 'Object',
+          'constructorFunction': {
+            'ref': globalExecutionState.GetObjectEvalHandle()
+          },
+          'protoObject': {
+            'ref': globalExecutionState.GetObjectProtoEvalHandle()
+          },
+          'prototypeObject': {
+            'ref': globalExecutionState.GetObjectPrototypeEvalHandle()
+          },
+          'properties': properties
+        };
+
+        return scopeAndRef;
+      }
+    };
+
+    var _breakpoints = [];
+    var _pendingBreakpoints = [];
+
+    var BreakpointManager = {
+      GetBreakpoints: function() {
+        var breakpoints = CallHostFunction(chakraDebug.JsDiagGetBreakpoints);
+        var activeBreakpointList = [];
+        breakpoints.forEach(function(element, index, array) {
+          var bpId = element.breakpointId;
+          activeBreakpointList[bpId] = _breakpoints[bpId];
+        });
+        _breakpoints = activeBreakpointList;
+        return _breakpoints;
+      },
+      GetBreakpoint: function(id) {
+        return _breakpoints[id];
+      },
+      AddBreakpoint: function(v8Breakpoint) {
+        _breakpoints[v8Breakpoint.Id()] = v8Breakpoint;
+      },
+      AddPendingBreakpoint: function(request) {
+        _pendingBreakpoints.push(request);
+      },
+      ProcessPendingBreakpoints: function() {
+        var unResolvedBreakpoints = [];
+        var pendingBreakpointRequest;
+        while (pendingBreakpointRequest = _pendingBreakpoints.shift()) {
+          Logger.LogDebugJson(
+            'ProcessPendingBreakpoints pendingBreakpointRequest',
+            pendingBreakpointRequest);
+          try {
+            var response = new DebugManager.Utility.MakeResponse(
+                                                    pendingBreakpointRequest);
+            var v8CommandProcessor = new V8CommandProcessor();
+            v8CommandProcessor[pendingBreakpointRequest.command](
+                                   pendingBreakpointRequest, response, false);
+            if (response.success) {
+              var responseJson = JSON.stringify(response);
+              Logger.LogDebugJson('ProcessPendingBreakpoints responseJson',
+                                  responseJson);
+              chakraDebug.SendDelayedRespose(responseJson);
+            } else {
+              unResolvedBreakpoints.push(pendingBreakpointRequest);
+            }
+          } catch (ex) {
+            Logger.LogError('ProcessPendingBreakpoints exception: ' +
+                           ex.message,
+                           ex.stack);
+          }
+        }
+        Array.prototype.push.apply(_pendingBreakpoints, unResolvedBreakpoints);
+      },
+      RemoveBreakpoint: function(id) {
+        var v8Breakpoint = _breakpoints[id];
+        if (v8Breakpoint) {
+          v8Breakpoint.Remove();
+          delete _breakpoints[id];
+        }
+      }
+    };
+
+    var _scripts = [];
+    var _scriptHandles = [];
+
+    var ScriptsManager = {
+      GetScripts: function() {
+        var scriptsArray = CallHostFunctionNoLog(chakraDebug.JsDiagGetScripts);
+        scriptsArray.forEach(function(element, index, array) {
+          if (!_scripts[element.scriptId]) {
+            var scriptHandle = GetNextInternalHandle();
+            _scriptHandles[scriptHandle] = scriptHandle;
+            _scripts[element.scriptId] = new V8Script(element, scriptHandle);
+          }
+        });
+        return _scripts;
+      },
+      GetScript: function(scriptId) {
+        if (!_scripts[scriptId]) {
+          this.GetScripts();
+        }
+        return _scripts[scriptId];
+      },
+      IsScriptHandle: function(handle) {
+        return (_scriptHandles[handle]) ? true : false;
+      },
+      GetScriptFromHandle: function(handle) {
+        for (var i = 0; i < _scripts.length; ++i) {
+          if (_scripts[i] && _scripts[i].GetHandle() == handle) {
+            return _scripts[i];
+          }
+        }
+      },
+      GetScriptFromFileName: function(fileName) {
+        var scripts = this.GetScripts();
+        for (var i = 0; i < scripts.length; ++i) {
+          if (scripts[i] && scripts[i].IsSameFileName(fileName)) {
+            return scripts[i];
+          }
+        }
+      },
+      GetScriptFromMatchingFileName: function(regexToMatch) {
+        var scripts = this.GetScripts();
+        for (var i = 0; i < scripts.length; ++i) {
+          if (scripts[i] && scripts[i].GetFileName() &&
+            scripts[i].GetFileName().match(regexToMatch)) {
+            return scripts[i];
+          }
+        }
+      }
+    };
+
+    return {
+      Utility: Utility, BreakpointManager: BreakpointManager,
+      ScriptsManager: ScriptsManager
+    };
+  })();
+
+
+  var ExecutionStateType = {
+    Break: 0,
+    Async: 1
+  };
+
+  function ExecutionState(stateType, scriptId) {
+    this.type = stateType;
+    this.breakScriptId = scriptId;
+    this.frames = undefined;
+    this.objectEval = undefined;
+    this.objectProtoEval = undefined;
+    this.objectPrototypeEval = undefined;
+  }
+
+  ExecutionState.prototype.ChangeToBreak = function() {
+    this.type = ExecutionStateType.Break;
+  };
+
+  ExecutionState.prototype.IsAsyncBreak = function() {
+    return this.type == ExecutionStateType.Async;
+  };
+
+  ExecutionState.prototype.GetBreakScriptId = function() {
+    return this.breakScriptId;
+  };
+
+  ExecutionState.prototype.GetFrames = function() {
+    if (!this.frames || this.frames.length == 0) {
+      var _frames = [];
+      var stackTrace = CallHostFunction(chakraDebug.JsDiagGetStackTrace);
+      stackTrace.forEach(function(element, index, array) {
+        _frames.push(new V8Frame(element));
+      });
+
+      this.frames = _frames;
+    }
+    return this.frames;
+  };
+
+  ExecutionState.prototype.GetObjectEvalHandle = function() {
+    if (!this.objectEval) {
+      var objEval = CallHostFunction(chakraDebug.JsDiagEvaluate, 'Object', 0);
+      if (!objEval[0]) {
+        Logger.LogError('Evaluating Object failed');
+      }
+      this.objectEval = objEval[1];
+    }
+    return this.objectEval.handle;
+  };
+
+  ExecutionState.prototype.GetObjectProtoEvalHandle = function() {
+    if (!this.objectProtoEval) {
+      var objEval = CallHostFunction(chakraDebug.JsDiagEvaluate,
+        'Object.__proto__', 0);
+      if (!objEval[0]) {
+        Logger.LogError('Evaluating Object.__proto__ failed');
+      }
+      this.objectProtoEval = objEval[1];
+    }
+    return this.objectProtoEval.handle;
+  };
+
+  ExecutionState.prototype.GetObjectPrototypeEvalHandle = function() {
+    if (!this.objectPrototypeEval) {
+      var objEval = CallHostFunction(chakraDebug.JsDiagEvaluate,
+        'Object.prototype', 0);
+      if (!objEval[0]) {
+        Logger.LogError('Evaluating Object.prototype failed');
+      }
+      this.objectPrototypeEval = objEval[1];
+    }
+    return this.objectPrototypeEval.handle;
+  };
+
+
+  function V8Script(chakraScript, scriptHandle) {
+    this.chakraScript = chakraScript;
+    this.script = {};
+    this.script.handle = scriptHandle;
+    this.script.type = 'script';
+    this.script.name = ('fileName' in chakraScript) ?
+      chakraScript.fileName : chakraScript.scriptType;
+    this.script.id = chakraScript.scriptId;
+    this.script.lineOffset = 0;
+    this.script.columnOffset = 0;
+    this.script.lineCount = chakraScript.lineCount;
+    this.script.sourceStart = '';
+    this.script.sourceLength = chakraScript.sourceLength;
+    this.script.scriptType = 2;
+    this.script.compilationType = 0;
+    this.script.text = `${this.script.name} (lines: ${this.script.lineCount})`;
+  }
+
+  V8Script.prototype.GetId = function() {
+    return this.script.id;
+  };
+
+  V8Script.prototype.GetFileName = function() {
+    return this.chakraScript.fileName;
+  };
+
+  V8Script.prototype.GetScriptName = function() {
+    return this.name;
+  };
+
+  V8Script.prototype.GetHandle = function() {
+    return this.script.handle;
+  };
+
+  V8Script.prototype.GetProtocolObject = function() {
+    return this.script;
+  };
+
+  V8Script.prototype.IsSameFileName = function(fileName) {
+    if (fileName && this.GetFileName() &&
+      (this.GetFileName().toLowerCase() == fileName.toLowerCase())) {
+      return true;
+    }
+    return false;
+  };
+
+
+  function V8Frame(stackTrace) {
+    this.stackProperties = CallHostFunction(
+                      chakraDebug.JsDiagGetStackProperties, stackTrace.index);
+
+    var receiverRef = stackTrace.functionHandle;
+    if ('thisObject' in this.stackProperties &&
+      'handle' in this.stackProperties.thisObject) {
+      receiverRef = this.stackProperties.thisObject.handle;
+    }
+
+    var isAtReturn = false;
+    if ('returnValue' in this.stackProperties &&
+      'handle' in this.stackProperties.returnValue) {
+      isAtReturn = true;
+    }
+
+    this.frame = {};
+    this.frame.type = 'frame';
+    this.frame.index = stackTrace.index;
+    this.frame.receiver = {};
+    this.frame.receiver.ref = receiverRef;
+    this.frame.func = {};
+    this.frame.func.ref = stackTrace.functionHandle;
+    this.frame.script = {};
+    this.frame.script.ref = DebugManager.ScriptsManager.GetScript(
+                                             stackTrace.scriptId).GetHandle();
+    this.frame.constructCall = false;
+    this.frame.atReturn = isAtReturn;
+    this.frame.debuggerFrame = false;
+    this.frame.arguments = [];
+    this.frame.locals = [];
+    this.frame.position = 0;
+    this.frame.line = stackTrace.line;
+    this.frame.column = stackTrace.column;
+    this.frame.sourceLineText = stackTrace.sourceText;
+    this.frame.scopes = [];
+    this.frame.text = '';
+  }
+
+  V8Frame.prototype.GetStackProperties = function() {
+    return this.stackProperties;
+  };
+
+  V8Frame.prototype.GetProtocolObject = function() {
+    return this.frame;
+  };
+
+  V8Frame.prototype.GetIndex = function() {
+    return this.frame.index;
+  };
+
+  V8Frame.prototype.Evaluate = function(expression) {
+    return CallHostFunction(chakraDebug.JsDiagEvaluate, expression,
+      this.frame.index);
+  };
+
+
+  function V8Breakpoint(type, target, scriptObject, line, column) {
+    this.type = type;
+    this.target = target;
+    this.scriptObject = scriptObject;
+    this.line = line;
+    this.column = column;
+  }
+
+  V8Breakpoint.prototype.GetTypeString = function() {
+    if (this.type == Debug.ScriptBreakPointType.ScriptId) {
+      return 'scriptId';
+    } else if (this.type == Debug.ScriptBreakPointType.ScriptName) {
+      return 'scriptName';
+    } else if (this.type == Debug.ScriptBreakPointType.ScriptRegExp) {
+      return 'scriptRegExp';
+    }
+  };
+
+  V8Breakpoint.prototype.Set = function() {
+    // {"breakpointId":1,"line":2,"column":4,"scriptId":1,"parentScriptId":2}
+    var bpObject = CallHostFunction(chakraDebug.JsDiagSetBreakpoint,
+      this.scriptObject.GetId(), this.line, this.column);
+    if (!bpObject) {
+      return false;
+    }
+    this.v8breakpoint = {};
+    this.v8breakpoint.number = bpObject.breakpointId;
+    this.v8breakpoint.line = bpObject.line;
+    this.v8breakpoint.column = bpObject.column;
+    this.v8breakpoint.groupId = null;
+    this.v8breakpoint.hit_count = 0;
+    this.v8breakpoint.active = true;
+    this.v8breakpoint.condition = null;
+    this.v8breakpoint.ignoreCount = 0;
+    this.v8breakpoint.actual_locations = [];
+    this.v8breakpoint.actual_locations[0] = {};
+    this.v8breakpoint.actual_locations[0].line = bpObject.line;
+    this.v8breakpoint.actual_locations[0].column = bpObject.column;
+    this.v8breakpoint.actual_locations[0].script_id = bpObject.scriptId;
+    this.v8breakpoint.type = this.GetTypeString();
+    this.v8breakpoint.script_id = bpObject.scriptId;
+    this.v8breakpoint.script_name = this.scriptObject.GetScriptName();
+
+    if (this.type == Debug.ScriptBreakPointType.ScriptRegExp) {
+      this.v8breakpoint.script_regexp = this.target;
+    }
+
+    return true;
+  };
+
+  V8Breakpoint.prototype.IncreaseHit = function() {
+    this.v8breakpoint.hit_count++;
+  };
+
+  V8Breakpoint.prototype.Remove = function() {
+    CallHostFunction(chakraDebug.JsDiagRemoveBreakpoint, this.Id());
+  };
+
+  V8Breakpoint.prototype.Id = function() {
+    return this.v8breakpoint.number;
+  };
+
+  V8Breakpoint.prototype.line = function() {
+    return this.bpObject.line;
+  };
+
+  V8Breakpoint.prototype.column = function() {
+    return this.bpObject.column;
+  };
+
+  V8Breakpoint.prototype.GetProtocolObject = function() {
+    return this.v8breakpoint;
+  };
+
+
+  function V8CommandProcessor() {}
+  // Supported commands
+  V8CommandProcessor.prototype.scripts = function(request, response) {
+    var v8Scripts = DebugManager.ScriptsManager.GetScripts();
+
+    if (request.arguments) {
+      var ids;
+      var filter;
+      var includeSource = false;
+
+      if (request.arguments.ids) {
+        ids = request.arguments.ids;
+      }
+
+      if (request.arguments.includeSource) {
+        includeSource = true;
+      }
+
+      if (request.arguments.filter) {
+        filter = request.arguments.filter;
+      }
+
+      var body = [];
+      v8Scripts.forEach(function(element, index, array) {
+        var found = true;
+
+        if (ids != null) {
+          found = false;
+          for (var i = 0; i < ids.length; ++i) {
+            if (ids[i] == element.GetId()) {
+              found = true;
+              break;
+            }
+          }
+        }
+
+        if (filter != null) {
+          found = filter == element.GetFileName();
+        }
+
+        if (found) {
+          var scriptObj = element.GetProtocolObject();
+          if (includeSource) {
+            var chakraSourceObj = CallHostFunctionNoLog(
+              chakraDebug.JsDiagGetSource, element.GetId());
+            scriptObj.source = chakraSourceObj.source;
+            scriptObj.lineCount = chakraSourceObj.lineCount;
+            scriptObj.sourceLength = chakraSourceObj.sourceLength;
+          }
+          body.push(scriptObj);
+        }
+      });
+
+      response.success = true;
+      response.body = body;
+    }
+  };
+
+  V8CommandProcessor.prototype.source = function(request, response) {
+    var chakraSourceObj = CallHostFunctionNoLog(chakraDebug.JsDiagGetSource,
+      globalExecutionState.GetBreakScriptId());
+    response.success = true;
+    response.body = {};
+    response.body.source = chakraSourceObj.source;
+    response.body.fromLine = 0;
+    response.body.toLine = chakraSourceObj.lineCount;
+    response.body.fromPosition = 0;
+    response.body.toPosition = chakraSourceObj.sourceLength;
+    response.body.totalLines = chakraSourceObj.lineCount;
+  };
+
+  V8CommandProcessor.prototype.continue = function(request, response) {
+    var success = true;
+    if (request.arguments && request.arguments.stepaction) {
+      var jsDiagSetStepType = 0;
+      if (request.arguments.stepaction == 'in') {
+        /* JsDiagStepTypeStepIn */
+        jsDiagSetStepType = 0;
+      } else if (request.arguments.stepaction == 'out') {
+        /* JsDiagStepTypeStepOut */
+        jsDiagSetStepType = 1;
+      } else if (request.arguments.stepaction == 'next') {
+        /* JsDiagStepTypeStepOver */
+        jsDiagSetStepType = 2;
+      } else {
+        throw new Error('Unhandled stepaction: ' +
+          request.arguments.stepaction);
+      }
+
+      if (!CallHostFunction(chakraDebug.JsDiagSetStepType,
+        jsDiagSetStepType)) {
+        success = false;
+      }
+    }
+
+    response.success = success;
+
+    // We are continuing, delete the globalExecutionState
+    globalExecutionState = undefined;
+  };
+
+  V8CommandProcessor.prototype.setbreakpoint = function(request, response,
+    optAddToPending) {
+    var breakpointType;
+    var breakpointScript;
+    var breakpointTarget;
+    var line = 0;
+    var column = 0;
+
+    if (request.arguments) {
+      var scriptObject;
+      if (request.arguments.type == 'scriptRegExp') {
+        var targetRegex = new RegExp(request.arguments.target);
+        scriptObject =
+          DebugManager.ScriptsManager.GetScriptFromMatchingFileName(
+          targetRegex);
+        if (scriptObject) {
+          breakpointScript = scriptObject;
+          breakpointType = Debug.ScriptBreakPointType.ScriptRegExp;
+          breakpointTarget = request.arguments.target;
+        }
+      } else if (request.arguments.type == 'script' &&
+        (request.arguments.target == null ||
+        request.arguments.target == undefined)) {
+        var breakScriptId = globalExecutionState.GetBreakScriptId();
+        scriptObject = DebugManager.ScriptsManager.GetScript(breakScriptId);
+        if (scriptObject) {
+          breakpointScript = scriptObject;
+          breakpointType = Debug.ScriptBreakPointType.ScriptId;
+          breakpointTarget = request.arguments.target;
+        }
+      } else if (request.arguments.type == 'script' &&
+        request.arguments.target) {
+        scriptObject = DebugManager.ScriptsManager.GetScriptFromFileName(
+          request.arguments.target);
+        if (scriptObject) {
+          breakpointScript = scriptObject;
+          breakpointType = Debug.ScriptBreakPointType.ScriptName;
+          breakpointTarget = request.arguments.target;
+        }
+      } else if (request.arguments.type == 'scriptId' &&
+        request.arguments.target) {
+        var scriptId = parseInt(request.arguments.target);
+        scriptObject = DebugManager.ScriptsManager.GetScript(scriptId);
+        if (scriptObject) {
+          breakpointScript = scriptObject;
+          breakpointType = Debug.ScriptBreakPointType.ScriptId;
+          breakpointTarget = request.arguments.target;
+        }
+      }
+
+      if (typeof request.arguments.line == 'number') {
+        line = request.arguments.line;
+      }
+
+      if (typeof request.arguments.column == 'number') {
+        column = request.arguments.column;
+      }
+    }
+
+    if (breakpointScript) {
+      var v8Breakpoint = new V8Breakpoint(breakpointType, breakpointTarget,
+        breakpointScript, line, column);
+      var success = false;
+      if (v8Breakpoint.Set()) {
+        success = true;
+        DebugManager.BreakpointManager.AddBreakpoint(v8Breakpoint);
+      }
+      response.success = success;
+      response.body = request.arguments;
+      response.body.actual_locations = [];
+      if (success) {
+        response.body.breakpoint = v8Breakpoint.Id();
+      }
+    } else {
+      if (optAddToPending != false) {
+        DebugManager.BreakpointManager.AddPendingBreakpoint(request);
+      }
+    }
+  };
+
+  V8CommandProcessor.prototype.backtrace = function(request, response) {
+    var frames = globalExecutionState.GetFrames();
+    var fromFrame = 0;
+    var toFrame = frames.length;
+
+    if (request.arguments) {
+      if (request.arguments.fromFrame != undefined) {
+        fromFrame = request.arguments.fromFrame;
+      }
+      if (request.arguments.toFrame != undefined &&
+        request.arguments.toFrame < toFrame) {
+        toFrame = request.arguments.toFrame;
+      }
+    }
+
+    response.body = {};
+    response.body.fromFrame = fromFrame,
+    response.body.toFrame = toFrame,
+    response.body.totalFrames = frames.length,
+    response.body.frames = [];
+    response.refs = [];
+
+    for (var i = fromFrame; i < toFrame; ++i) {
+      response.body.frames.push(frames[i].GetProtocolObject());
+    }
+
+    response.success = true;
+  };
+
+  V8CommandProcessor.prototype.lookup = function(request, response) {
+    var handlesResult = {};
+    request.arguments.handles.map(function(handle) {
+      var handleObject = null;
+      if (DebugManager.ScriptsManager.IsScriptHandle(handle)) {
+        handleObject = DebugManager.ScriptsManager.GetScriptFromHandle(handle);
+        if (handleObject) {
+          handleObject = handleObject.GetProtocolObject();
+        }
+      } else {
+        handleObject = CallHostFunction(chakraDebug.JsDiagGetObjectFromHandle,
+          handle);
+        if (handleObject) {
+          AddChildrens(handleObject);
+        }
+      }
+
+      if (handleObject) {
+        if ('fileName' in handleObject && !('name' in handleObject)) {
+          handleObject['name'] = handleObject['fileName'];
+        }
+
+        if ('scriptId' in handleObject && !('id' in handleObject)) {
+          handleObject['id'] = handleObject['scriptId'];
+        }
+
+        if ('scriptType' in handleObject && !('name' in handleObject)) {
+          handleObject['name'] = handleObject['scriptType'];
+        }
+
+        handlesResult[handle] = handleObject;
+      }
+    });
+
+    response.success = true;
+    response.body = handlesResult;
+    response.refs = [];
+  };
+
+  V8CommandProcessor.prototype.evaluate = function(request, response) {
+    if (globalExecutionState) {
+      var frames = globalExecutionState.GetFrames();
+      var frame = frames[0];
+      if (request.arguments) {
+        if (typeof request.arguments.frame == 'number') {
+          for (var i = 0; i < frames.length; ++i) {
+            if (request.arguments.frame == frames[i].GetIndex()) {
+              frame = frames[i];
+              break;
+            }
+          }
+        } else if (request.arguments.global == true) {
+          frame = frames[frames.length - 1];
+        }
+
+        var evalResult = frame.Evaluate(request.arguments.expression);
+        AddChildrens(evalResult[1]);
+        response.success = evalResult[0];
+        response.body = evalResult[1];
+        response.refs = [];
+      } else {
+        response.success = false;
+      }
+    } else {
+      response.pending = true;
+      pendingMessages.push({ request: request, response: response });
+    }
+  };
+
+  V8CommandProcessor.prototype.threads = function(request, response) {
+    response.body = {
+      'totalThreads': 1,
+      'threads': [{
+        'current': true,
+        'id': 1
+      }
+      ]
+    };
+    response.success = true;
+    response.refs = [];
+  };
+
+  V8CommandProcessor.prototype.setexceptionbreak =
+    function(request, response) {
+      var enabled = false;
+      // JsDiagBreakOnExceptionAttributeNone
+      var breakOnExceptionAttribute = 0;
+      if (request.arguments) {
+        if (request.arguments.enabled) {
+          enabled = request.arguments.enabled;
+        }
+
+        if (enabled && request.arguments.type) {
+          if (request.arguments.type == 'all') {
+            // JsDiagBreakOnExceptionAttributeUncaught |
+            // JsDiagBreakOnExceptionAttributeFirstChance
+            breakOnExceptionAttribute = 0x1 | 0x2;
+          } else if (request.arguments.type == 'uncaught') {
+            // JsDiagBreakOnExceptionAttributeUncaught
+            breakOnExceptionAttribute = 0x1;
+          }
+        }
+      }
+
+      var success = CallHostFunction(chakraDebug.JsDiagSetBreakOnException,
+        breakOnExceptionAttribute);
+      response.success = success ? true : false;
+
+      response.body = {};
+      response.body.type = request.arguments.type;
+      response.body.enabled = enabled;
+      response.refs = [];
+    };
+
+  V8CommandProcessor.prototype.scopes = function(request, response) {
+    var frames = globalExecutionState.GetFrames();
+    var frameIndex = -1;
+    var frame;
+    for (var i = 0; i < frames.length; ++i) {
+      if (frames[i].GetIndex() == request.arguments.frameNumber) {
+        frameIndex = frames[i].GetIndex();
+        frame = frames[i];
+        break;
+      }
+    }
+
+    if (frameIndex != -1) {
+      var props = frame.GetStackProperties();
+      var scopes = [];
+      var refs = [];
+      var locals = [];
+
+      ['exception', 'arguments', 'thisObject', 'returnValue'].forEach(
+        function(prop) {
+          if (prop in props) {
+            locals.push(props[prop]);
+          }
+        });
+
+      ['functionCallsReturn', 'locals'].forEach(function(prop) {
+        if (prop in props) {
+          props[prop].forEach(function(element) {
+            locals.push(element);
+          });
+        }
+      });
+
+      //var scopesMap = { 'locals': 1, 'globals': 0, 'scopes': 3 };
+      if (locals.length > 0) {
+        var scopeAndRef = DebugManager.Utility.CreateScopeAndRef(1, locals,
+          frameIndex, request.arguments.frame_index);
+        scopes.push(scopeAndRef.scope);
+        refs.push(scopeAndRef.ref);
+      }
+
+      if (props['scopes'] && props['scopes'].length > 0) {
+        var allScopeProperties = [];
+        props['scopes'].map(function(scope) {
+          var scopeHandle = scope.handle;
+
+          var scopeProperties = CallHostFunction(
+            chakraDebug.JsDiagGetProperties, scopeHandle, 0, 1000);
+
+          scopeProperties['properties'].map(function(property) {
+            allScopeProperties.push(property);
+          });
+          scopeProperties['debuggerOnlyProperties'].map(function(dbgProp) {
+            allScopeProperties.push(dbgProp);
+          });
+        });
+
+        if (allScopeProperties.length > 0) {
+          var allScopeAndRef = DebugManager.Utility.CreateScopeAndRef(3,
+            allScopeProperties, frameIndex, request.arguments.frame_index);
+          scopes.push(allScopeAndRef.scope);
+          refs.push(allScopeAndRef.ref);
+        }
+      }
+
+      if (props['globals'] && props['globals'].handle) {
+        var globalsProps = CallHostFunction(chakraDebug.JsDiagGetProperties,
+          props['globals'].handle, 0, 5000);
+
+        var globalProperties = [];
+        globalsProps['properties'].map(function(glbProperty) {
+          globalProperties.push(glbProperty);
+        });
+        globalsProps['debuggerOnlyProperties'].map(function(glbDbgProp) {
+          globalProperties.push(glbDbgProp);
+        });
+        if (globalProperties.length > 0) {
+          var glbScopeAndRef = DebugManager.Utility.CreateScopeAndRef(0,
+            globalProperties, frameIndex, request.arguments.frame_index);
+          scopes.push(glbScopeAndRef.scope);
+          refs.push(glbScopeAndRef.ref);
+        }
+      }
+
+      response['success'] = true;
+      response['refs'] = refs;
+      response['body'] = {
+        'fromScope': 0,
+        'toScope': scopes.length,
+        'totalScopes': scopes.length,
+        'scopes': scopes
+      };
+    }
+  };
+
+  V8CommandProcessor.prototype.scope = function(request, response) { };
+
+  V8CommandProcessor.prototype.listbreakpoints = function(request, response) {
+    // {'command':'listbreakpoints','type':'request','seq':25}
+    var breakOnExceptionAttribute = CallHostFunction(
+      chakraDebug.JsDiagGetBreakOnException);
+
+    response.success = true;
+    response.body = {};
+    response.body.breakpoints = [];
+    response.body.breakOnExceptions = breakOnExceptionAttribute != 0;
+    response.body.breakOnUncaughtExceptions =
+      (breakOnExceptionAttribute & 0x1) == 0x1;
+
+    var breakpoints = DebugManager.BreakpointManager.GetBreakpoints();
+
+    breakpoints.forEach(function(element, index, array) {
+      if (element) {
+        response.body.breakpoints.push(element.GetProtocolObject());
+      }
+    });
+  };
+
+  V8CommandProcessor.prototype.clearbreakpoint = function(request, response) {
+    if (request.arguments.breakpoint) {
+      response.success = true;
+      DebugManager.BreakpointManager.RemoveBreakpoint(
+        request.arguments.breakpoint);
+    }
+  };
+
+  V8CommandProcessor.prototype.suspend = function(request, response) {
+    if (globalExecutionState) {
+      response.success = true;
+      globalExecutionState.ChangeToBreak();
+    } else {
+      request.pending = true;
+      pendingMessages.push({ request: request, response: response });
+    }
+  };
+
+  // Not supported commands
+  V8CommandProcessor.prototype.break = function(request, response) { };
+  V8CommandProcessor.prototype.changebreakpoint =
+    function(request, response) { };
+  V8CommandProcessor.prototype.changelive = function(request, response) { };
+  V8CommandProcessor.prototype.clearbreakpointgroup =
+    function(request, response) { };
+  V8CommandProcessor.prototype.disconnect = function(request, response) { };
+  V8CommandProcessor.prototype.flags = function(request, response) { };
+  V8CommandProcessor.prototype.frame = function(request, response) { };
+  V8CommandProcessor.prototype.gc = function(request, response) { };
+  V8CommandProcessor.prototype.references = function(request, response) { };
+  V8CommandProcessor.prototype.restartframe = function(request, response) { };
+  V8CommandProcessor.prototype.setvariablevalue =
+    function(request, response) { };
+  V8CommandProcessor.prototype.v8flag = function(request, response) { };
+  V8CommandProcessor.prototype.version = function(request, response) { };
+
+
+  var ChakraDebugEvent = {
+    SourceCompile: 0,
+    CompileError: 1,
+    Breakpoint: 2,
+    StepComplete: 3,
+    DebuggerStatement: 4,
+    AsyncBreak: 5,
+    RuntimeException: 6
+  };
+
+  function ChakraDebugEventProcessor(eventData) {
+    this.eventData = eventData;
+    this.ProcessPendingMessages = function(isAsyncBreak) {
+      var pendingObject;
+      while (pendingObject = pendingMessages.shift()) {
+        try {
+          var request = pendingObject.request;
+          var response = pendingObject.response;
+          Logger.LogAPI('ProcessPendingMessages request', request);
+          var v8CommandProcessor = new V8CommandProcessor();
+          v8CommandProcessor[request.command](request, response);
+          if (!request.pending) {
+            var responseJson = JSON.stringify(response);
+            Logger.LogDebugJson('ProcessPendingMessages responseJson',
+                                responseJson);
+            chakraDebug.SendDelayedRespose(responseJson);
+          }
+        } catch (ex) {
+          Logger.LogError('ProcessPendingMessages exception: ' + ex.message,
+                          ex.stack);
+        }
+      }
+    };
+  }
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.SourceCompile] =
+    function() {
+      var event = DebugManager.Utility.MakeEvent('afterCompile');
+      event.body = {};
+
+      var scriptObj = DebugManager.ScriptsManager.GetScript(
+        this.eventData.scriptId);
+      event.body.script = scriptObj.GetProtocolObject();
+
+      DebugManager.BreakpointManager.ProcessPendingBreakpoints();
+
+      return event;
+    };
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.CompileError] =
+    function() { };
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.Breakpoint] =
+    function() {
+      globalExecutionState = new ExecutionState(ExecutionStateType.Break,
+        this.eventData.scriptId);
+
+      this.ProcessPendingMessages(false);
+
+      var scriptObj = DebugManager.ScriptsManager.GetScript(
+        globalExecutionState.GetBreakScriptId());
+      var event = DebugManager.Utility.MakeEvent('break');
+      event.body = {};
+      event.body.sourceLine = this.eventData.line;
+      event.body.sourceColumn = this.eventData.column;
+      event.body.sourceLineText = this.eventData.sourceText;
+      event.body.script = scriptObj.GetProtocolObject();
+
+      var v8Breakpoint = DebugManager.BreakpointManager.GetBreakpoint(
+        this.eventData.breakpointId);
+      if (v8Breakpoint) {
+        v8Breakpoint.IncreaseHit();
+        event.body.breakpoints = [v8Breakpoint.Id()];
+      }
+
+      return event;
+    };
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.StepComplete] =
+    ChakraDebugEventProcessor.prototype[ChakraDebugEvent.Breakpoint];
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.DebuggerStatement] =
+    ChakraDebugEventProcessor.prototype[ChakraDebugEvent.Breakpoint];
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.AsyncBreak] =
+    function() {
+
+      globalExecutionState = new ExecutionState(ExecutionStateType.Async,
+        this.eventData.scriptId);
+
+      this.ProcessPendingMessages(true);
+    };
+
+  ChakraDebugEventProcessor.prototype[ChakraDebugEvent.RuntimeException] =
+    function() {
+      globalExecutionState = new ExecutionState(ExecutionStateType.Break,
+        this.eventData.scriptId);
+
+      this.ProcessPendingMessages(false);
+
+      var scriptObj = DebugManager.ScriptsManager.GetScript(
+        globalExecutionState.GetBreakScriptId());
+      var event = DebugManager.Utility.MakeEvent('exception');
+      event.body = {};
+      event.body.sourceLine = this.eventData.line;
+      event.body.sourceColumn = this.eventData.column;
+      event.body.sourceLineText = this.eventData.sourceText;
+      event.body.script = scriptObj.GetProtocolObject();
+      return event;
+    };
+
+  function DebugEventToString(debugEvent) {
+    switch (debugEvent) {
+      case 0:
+        return 'JsDiagDebugEventSourceCompile';
+      case 1:
+        return 'JsDiagDebugEventCompileError';
+      case 2:
+        return 'JsDiagDebugEventBreakpoint';
+      case 3:
+        return 'JsDiagDebugEventStepComplete';
+      case 4:
+        return 'JsDiagDebugEventDebuggerStatement';
+      case 5:
+        return 'JsDiagDebugEventAsyncBreak';
+      case 6:
+        return 'JsDiagDebugEventRuntimeException';
+      default:
+        return 'Unhandled JsDiagDebugEvent: ' + debugEvent;
+    }
+  }
+
+  var chakraDebug = {};
+
+  chakraDebug.ProcessDebuggerMessage = function(request) {
+    Logger.LogAPI('ProcessDebuggerMessage request', request);
+    try {
+      request = JSON.parse(request);
+      var response = new DebugManager.Utility.MakeResponse(request);
+      var v8CommandProcessor = new V8CommandProcessor();
+      v8CommandProcessor[request.command](request, response);
+
+      var responseJson = response.pending ? undefined :
+        JSON.stringify(response);
+      Logger.LogDebugJson('ProcessDebuggerMessage responseJson', responseJson);
+      return responseJson;
+    } catch (ex) {
+      Logger.LogError('ProcessDebuggerMessage exception: ' + ex.message,
+                      ex.stack);
+    }
+  };
+
+  chakraDebug.ProcessDebugEvent = function(debugEvent, eventData) {
+    Logger.LogAPI('ProcessDebugEvent debugEvent: ' +
+      DebugEventToString(debugEvent) + ', eventData: ' +
+      JSON.stringify(eventData));
+    try {
+      var chakraDebugEventProcessor = new ChakraDebugEventProcessor(eventData);
+      var event = chakraDebugEventProcessor[debugEvent]();
+      if (typeof event != 'undefined') {
+        event = JSON.stringify(event);
+      }
+      Logger.LogDebugJson('ProcessDebugEvent debugEvent: ' +
+        DebugEventToString(debugEvent) + ', event: ' + event);
+      return event;
+    } catch (ex) {
+      Logger.LogError('ProcessDebugEvent exception: ' + ex.message, ex.stack);
+    }
+  };
+
+  chakraDebug.ProcessShouldContinue = function(debugEvent) {
+    var shouldContinue = true;
+
+    if (!globalExecutionState) {
+      shouldContinue = true;
+    } else if (typeof debugEvent == 'number' &&
+      ((debugEvent == 0 /*JsDiagDebugEventSourceCompile*/) ||
+      (debugEvent == 1 /*JsDiagDebugEventCompileError*/))) {
+      shouldContinue = true;
+    } else if (globalExecutionState.IsAsyncBreak()) {
+      globalExecutionState = undefined;
+      shouldContinue = true;
+    } else {
+      shouldContinue = false;
+    }
+    return shouldContinue;
+  };
+
+  keepAliveObject.chakraDebug = chakraDebug;
+
+  return keepAliveObject.chakraDebug;
+});

--- a/deps/chakrashim/src/jsrtcontextshim.cc
+++ b/deps/chakrashim/src/jsrtcontextshim.cc
@@ -23,6 +23,11 @@
 #include <algorithm>
 #include <memory>
 
+namespace v8 {
+  extern bool g_trace_debug_json;
+  extern __declspec(thread) JsSourceContext currentContext;
+}
+
 namespace jsrt {
 
 ContextShim::Scope::Scope(ContextShim * contextShim) {
@@ -432,7 +437,7 @@ bool ContextShim::ExecuteChakraShimJS() {
 
   JsValueRef getInitFunction;
   if (JsParseScript(buffer,
-                    JS_SOURCE_CONTEXT_NONE,
+                    v8::currentContext++,
                     L"chakra_shim.js",
                     &getInitFunction) != JsNoError) {
     return false;
@@ -445,6 +450,46 @@ bool ContextShim::ExecuteChakraShimJS() {
   JsValueRef arguments[] = { this->globalObject, this->keepAliveObject };
   return JsCallFunction(initFunction, arguments, _countof(arguments),
                         &result) == JsNoError;
+}
+
+bool ContextShim::ExecuteChakraDebugShimJS(JsValueRef * chakraDebugObject) {
+  wchar_t buffer[_countof(chakra_debug_native) + 1];
+
+  if (StringConvert::CopyRaw<unsigned char, wchar_t>(chakra_debug_native,
+    _countof(chakra_debug_native),
+    buffer,
+    _countof(chakra_debug_native)) != JsNoError) {
+    return false;
+  }
+
+  // Ensure the buffer is null terminated
+  buffer[_countof(chakra_debug_native)] = L'\0';
+
+  JsValueRef getInitFunction;
+  if (JsParseScriptWithAttributes(buffer,
+    v8::currentContext++,
+    L"chakra_debug.js",
+    JsParseScriptAttributeNone,
+    &getInitFunction) != JsNoError) {
+    return false;
+  }
+
+  JsValueRef initFunction;
+  if (CallFunction(getInitFunction, &initFunction) != JsNoError) {
+    return false;
+  }
+
+  JsValueRef traceDebugJsonRef;
+  JsBoolToBoolean(v8::g_trace_debug_json, &traceDebugJsonRef);
+
+  JsValueRef arguments[] = { this->globalObject, this->globalObject,
+      this->keepAliveObject, traceDebugJsonRef };
+  JsErrorCode errorCode = JsCallFunction(initFunction, arguments,
+      _countof(arguments), chakraDebugObject);
+
+  CHAKRA_VERIFY_NOERROR(errorCode);
+
+  return true;
 }
 
 void ContextShim::SetAlignedPointerInEmbedderData(int index, void * value) {

--- a/deps/chakrashim/src/jsrtcontextshim.h
+++ b/deps/chakrashim/src/jsrtcontextshim.h
@@ -54,6 +54,8 @@ class ContextShim {
   ~ContextShim();
   void EnsureInitialized();
 
+  bool ExecuteChakraDebugShimJS(JsValueRef * chakraDebugObject);
+
   IsolateShim * GetIsolateShim();
   JsContextRef GetContextRef();
 

--- a/deps/chakrashim/src/jsrtdebug.cc
+++ b/deps/chakrashim/src/jsrtdebug.cc
@@ -1,0 +1,680 @@
+// Copyright Microsoft. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and / or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include "jsrtdebug.h"
+#include "jsrtutils.h"
+
+namespace v8 {
+  extern __declspec(thread) bool g_EnableDebug;
+}
+
+namespace jsrt {
+
+  MessageQueue Debugger::messageQueue;
+  v8::Debug::MessageHandler Debugger::handler = nullptr;
+
+  MessageImpl::MessageImpl(v8::Local<v8::String> v8Str) {
+    this->v8Str = v8Str;
+  }
+
+  v8::Isolate* MessageImpl::GetIsolate() const {
+    return jsrt::IsolateShim::GetCurrentAsIsolate();
+  }
+
+  v8::Local<v8::String> MessageImpl::JsValueRefToV8String(JsValueRef result) {
+    JsValueRef scriptRef;
+    const wchar_t *script;
+
+    JsErrorCode errorCode = jsrt::ToString(result, &scriptRef, &script);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    v8::Local<v8::String> v8Str = v8::String::NewFromTwoByte(
+      jsrt::IsolateShim::GetCurrentAsIsolate(),
+      reinterpret_cast<uint16_t*>(const_cast<wchar_t*>(script)));
+    return v8Str;
+  }
+
+  v8::Local<v8::String> MessageImpl::GetJSON() const {
+    return this->v8Str;
+  }
+
+  MessageQueue::MessageQueue() {
+    this->waitingForMessage = false;
+    this->isProcessingDebuggerMsg = false;
+    this->debugEventProcessCount = 0;
+    this->msgQueue = new std::queue<uint16_t*>();
+
+    int err = uv_sem_init(&newMsgSem, 0);
+    CHAKRA_VERIFY(err == 0);
+    err = uv_mutex_init(&msgMutex);
+    CHAKRA_VERIFY(err == 0);
+  }
+
+  MessageQueue::~MessageQueue() {
+    uv_mutex_destroy(&msgMutex);
+    uv_sem_destroy(&newMsgSem);
+    delete this->msgQueue;
+    this->msgQueue = nullptr;
+  }
+
+  void MessageQueue::SaveMessage(const uint16_t* command, int length) {
+    uint16_t* commandCopy = new uint16_t[length + 1];
+    for (int i = 0; i < length; i++) commandCopy[i] = command[i];
+    commandCopy[length] = '\0';
+
+    uv_mutex_lock(&msgMutex);
+    this->msgQueue->push(commandCopy);
+
+    if (this->waitingForMessage) {
+      uv_sem_post(&newMsgSem);
+      this->waitingForMessage = false;
+    }
+
+    uv_mutex_unlock(&msgMutex);
+  }
+
+  uint16_t* MessageQueue::PopMessage() {
+    uv_mutex_lock(&msgMutex);
+    uint16_t* command = this->msgQueue->front();
+    this->msgQueue->pop();
+    uv_mutex_unlock(&msgMutex);
+    return command;
+  }
+
+  bool MessageQueue::IsEmpty() {
+    return this->msgQueue->empty();
+  }
+
+  void MessageQueue::WaitForMessage() {
+    uv_mutex_lock(&msgMutex);
+
+    if (!this->IsEmpty()) {
+      uv_mutex_unlock(&msgMutex);
+      return;
+    }
+
+    this->waitingForMessage = true;
+    uv_mutex_unlock(&msgMutex);
+    uv_sem_wait(&newMsgSem);
+  }
+
+  void MessageQueue::SetProcessMessageFunctions(
+    JsValueRef chakraDebugObject,
+    JsValueRef processDebuggerMessageFn,
+    JsValueRef processDebugEventFn,
+    JsValueRef processShouldContinueFn) {
+    this->chakraDebugObject = chakraDebugObject;
+    this->processDebuggerMessageFn = processDebuggerMessageFn;
+    this->processDebugEventFn = processDebugEventFn;
+    this->processShouldContinueFn = processShouldContinueFn;
+  }
+
+  void MessageQueue::ProcessDebuggerMessage() {
+    if (this->isProcessingDebuggerMsg) {
+      return;
+    }
+
+    if (!this->IsEmpty()) {
+      this->isProcessingDebuggerMsg = true;
+
+      uint16_t* command = this->PopMessage();
+      v8::Local<v8::String> commandJson = v8::String::NewFromTwoByte(
+        jsrt::IsolateShim::GetCurrentAsIsolate(), command);
+
+      JsValueRef args[] = { jsrt::GetUndefined(), *commandJson };
+      JsValueRef responseRef;
+      JsErrorCode errorCode = JsCallFunction(
+        this->processDebuggerMessageFn, args, _countof(args), &responseRef);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+
+      delete command;
+
+      JsValueType resultType;
+      errorCode = JsGetValueType(responseRef, &resultType);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+
+      if (resultType == JsString) {
+        v8::Local<v8::String> v8Str =
+          MessageImpl::JsValueRefToV8String(responseRef);
+        MessageImpl* msgImpl = new MessageImpl(v8Str);
+        Debugger::handler(*msgImpl);
+      }
+
+      this->isProcessingDebuggerMsg = false;
+    }
+  }
+
+  void MessageQueue::ProcessDebugEvent(
+    JsDiagDebugEvent debugEvent,
+    JsValueRef eventData) {
+    JsValueRef debugEventRef;
+    JsErrorCode errorCode = JsIntToNumber(debugEvent, &debugEventRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef args[] = { jsrt::GetUndefined(), debugEventRef, eventData };
+    JsValueRef result;
+    errorCode = JsCallFunction(
+      this->processDebugEventFn, args, _countof(args), &result);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueType resultType;
+    errorCode = JsGetValueType(result, &resultType);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    if (resultType == JsString) {
+      v8::Local<v8::String> v8Str = MessageImpl::JsValueRefToV8String(result);
+      MessageImpl* msgImpl = new MessageImpl(v8Str);
+      Debugger::handler(*msgImpl);
+    }
+  }
+
+  bool MessageQueue::ShouldContinue(JsDiagDebugEvent debugEvent) {
+    JsValueRef debugEventRef;
+    JsErrorCode errorCode = JsIntToNumber(debugEvent, &debugEventRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef args[] = { jsrt::GetUndefined(), debugEventRef };
+    JsValueRef result;
+    errorCode = JsCallFunction(
+      this->processShouldContinueFn, args, _countof(args), &result);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueType resultType;
+    errorCode = JsGetValueType(result, &resultType);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    CHAKRA_VERIFY(resultType == JsBoolean);
+
+    bool shouldContinue = true;
+    errorCode = JsBooleanToBool(result, &shouldContinue);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    return shouldContinue;
+  }
+
+  void CALLBACK JsDiagDebugEventHandler(
+    JsDiagDebugEvent debugEvent,
+    JsValueRef eventData,
+    void* callbackState) {
+    if (Debugger::handler == nullptr) {
+      return;
+    }
+
+    Debugger::messageQueue.debugEventProcessCount++;
+    bool isMsgToProcess = !Debugger::messageQueue.IsEmpty();
+    bool shouldContinue = true;
+    do {
+      if (eventData != nullptr) {
+        Debugger::messageQueue.ProcessDebugEvent(debugEvent, eventData);
+        eventData = nullptr;
+      }
+
+      // Process all messages received from debugger
+      if (Debugger::messageQueue.debugEventProcessCount <= 1) {
+        isMsgToProcess = !Debugger::messageQueue.IsEmpty();
+        while (!Debugger::messageQueue.isProcessingDebuggerMsg &&
+          isMsgToProcess) {
+          Debugger::messageQueue.ProcessDebuggerMessage();
+          isMsgToProcess = !Debugger::messageQueue.IsEmpty();
+        }
+      }
+
+      shouldContinue = Debugger::messageQueue.ShouldContinue(debugEvent);
+      if (!shouldContinue) {
+        Debugger::messageQueue.WaitForMessage();
+      }
+
+      isMsgToProcess = !Debugger::messageQueue.IsEmpty();
+    } while (isMsgToProcess &&
+      !Debugger::messageQueue.isProcessingDebuggerMsg && !shouldContinue);
+
+    Debugger::messageQueue.debugEventProcessCount--;
+  }
+
+  static JsValueRef CALLBACK Log(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef scriptRef;
+    const wchar_t *script;
+
+    if (argumentCount > 1 &&
+      jsrt::ToString(arguments[1], &scriptRef, &script) == JsNoError) {
+      fwprintf(stdout, L"%s\n", script);
+#ifdef DEBUG
+      flushall();
+#endif
+    }
+
+    return JS_INVALID_REFERENCE;
+  }
+
+  static JsValueRef CALLBACK SendDelayedRespose(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueType resultType;
+    JsErrorCode errorCode = JsGetValueType(arguments[1], &resultType);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    if (resultType == JsString) {
+      v8::Local<v8::String> v8Str = MessageImpl::JsValueRefToV8String(
+        arguments[1]);
+      MessageImpl* msgImpl = new MessageImpl(v8Str);
+      Debugger::handler(*msgImpl);
+    }
+
+    return JS_INVALID_REFERENCE;
+  }
+
+  static JsValueRef CALLBACK JsGetScripts(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef sourcesList;
+    JsErrorCode errorCode = JsDiagGetScripts(&sourcesList);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    return sourcesList;
+  }
+
+  static JsValueRef CALLBACK JsGetSource(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    int scriptId;
+    JsValueRef source = JS_INVALID_REFERENCE;
+    if (argumentCount > 1 &&
+      jsrt::ValueToInt(arguments[1], &scriptId) == JsNoError) {
+      JsErrorCode errorCode = JsDiagGetSource(scriptId, &source);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+    }
+
+    return source;
+  }
+
+  static JsValueRef CALLBACK JsSetStepType(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    bool success = false;
+    int stepType;
+    if (argumentCount > 1 &&
+      jsrt::ValueToInt(arguments[1], &stepType) == JsNoError) {
+      JsErrorCode errorCode = JsDiagSetStepType((JsDiagStepType)stepType);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+      success = true;
+    }
+
+    JsValueRef returnRef = JS_INVALID_REFERENCE;
+    JsBoolToBoolean(success, &returnRef);
+
+    return returnRef;
+  }
+
+  static JsValueRef CALLBACK JsSetBreakpoint(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    int scriptId;
+    int line;
+    int column;
+    JsValueRef bpObject = JS_INVALID_REFERENCE;
+
+    if (argumentCount > 3 &&
+      jsrt::ValueToInt(arguments[1], &scriptId) == JsNoError &&
+      jsrt::ValueToInt(arguments[2], &line) == JsNoError &&
+      jsrt::ValueToInt(arguments[3], &column) == JsNoError) {
+      JsErrorCode errorCode = JsDiagSetBreakpoint(
+        scriptId, line, column, &bpObject);
+    }
+
+    return bpObject;
+  }
+
+  static JsValueRef CALLBACK JsGetFunctionPosition(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef valueRef = JS_INVALID_REFERENCE;
+    JsErrorCode errorCode = JsConvertValueToObject(arguments[1], &valueRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+    JsValueRef funcInfo = JS_INVALID_REFERENCE;
+    errorCode = JsDiagGetFunctionPosition(valueRef, &funcInfo);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    return funcInfo;
+  }
+
+  static JsValueRef CALLBACK JsGetStackTrace(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef stackInfo = JS_INVALID_REFERENCE;
+    JsErrorCode errorCode = JsDiagGetStackTrace(&stackInfo);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    return stackInfo;
+  }
+
+  static JsValueRef CALLBACK JsGetStackProperties(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    int frameIndex;
+    JsValueRef properties = JS_INVALID_REFERENCE;
+    if (argumentCount > 1 &&
+      jsrt::ValueToInt(arguments[1], &frameIndex) == JsNoError) {
+      JsErrorCode errorCode = JsDiagGetStackProperties(frameIndex, &properties);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+    }
+
+    return properties;
+  }
+
+  static JsValueRef CALLBACK JsGetObjectFromHandle(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef properties = JS_INVALID_REFERENCE;
+    int handle;
+    if (argumentCount > 1 &&
+      jsrt::ValueToInt(arguments[1], &handle) == JsNoError) {
+      JsErrorCode errorCode = JsDiagGetObjectFromHandle(handle, &properties);
+    }
+
+    return properties;
+  }
+
+  static JsValueRef CALLBACK JsGetBreakpoints(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef properties = JS_INVALID_REFERENCE;
+    JsErrorCode errorCode = JsDiagGetBreakpoints(&properties);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    return properties;
+  }
+
+  static JsValueRef CALLBACK JsRemoveBreakpoint(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    int bpId;
+    if (argumentCount > 1 &&
+      jsrt::ValueToInt(arguments[1], &bpId) == JsNoError) {
+      JsErrorCode errorCode = JsDiagRemoveBreakpoint(bpId);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+    }
+
+    return JS_INVALID_REFERENCE;
+  }
+
+  static JsValueRef CALLBACK JsGetProperties(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef properties = JS_INVALID_REFERENCE;
+    int objectHandle;
+    int fromCount;
+    int totalCount;
+
+    if (argumentCount > 3 &&
+      jsrt::ValueToInt(arguments[1], &objectHandle) == JsNoError &&
+      jsrt::ValueToInt(arguments[2], &fromCount) == JsNoError &&
+      jsrt::ValueToInt(arguments[3], &totalCount) == JsNoError) {
+      JsErrorCode errorCode = JsDiagGetProperties(
+        objectHandle, fromCount, totalCount, &properties);
+      CHAKRA_VERIFY_NOERROR(errorCode);
+    }
+    return properties;
+  }
+
+  static JsValueRef CALLBACK JsEvaluate(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    int frameIndex;
+    JsValueRef scriptRef;
+    const wchar_t *script;
+    JsValueRef resultArray = JS_INVALID_REFERENCE;
+    JsValueRef result = JS_INVALID_REFERENCE;
+
+    if (argumentCount > 2 &&
+      jsrt::ValueToInt(arguments[2], &frameIndex) == JsNoError &&
+      jsrt::ToString(arguments[1], &scriptRef, &script) == JsNoError) {
+      JsErrorCode errorCode = JsDiagEvaluate(script, frameIndex, &result);
+      if (errorCode != JsNoError && errorCode != JsErrorScriptException) {
+        jsrt::Fatal("internal error %s(%d): %d", __FILE__, __LINE__,
+          errorCode);
+      }
+
+      JsCreateArray(2, &resultArray);
+
+      bool success = errorCode == JsNoError ? true : false;
+      JsValueRef resultBool;
+      JsBoolToBoolean(success, &resultBool);
+
+      JsValueRef arrayIndex;
+      JsIntToNumber(0, &arrayIndex);
+      JsSetIndexedProperty(resultArray, arrayIndex, resultBool);
+      JsIntToNumber(1, &arrayIndex);
+      JsSetIndexedProperty(resultArray, arrayIndex, result);
+    }
+
+    return resultArray;
+  }
+
+  static JsValueRef CALLBACK JsEvaluateScript(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsValueRef scriptRef;
+    const wchar_t *script;
+    JsValueRef result = JS_INVALID_REFERENCE;
+
+    if (argumentCount > 1 &&
+      jsrt::ToString(arguments[1], &scriptRef, &script) == JsNoError) {
+      JsErrorCode errorCode = JsRunScript(
+        script, JS_SOURCE_CONTEXT_NONE, L"", &result);
+      if (errorCode != JsNoError) {
+        JsValueRef excep;
+        JsGetAndClearException(&excep);
+      }
+    }
+
+    return result;
+  }
+
+  static JsValueRef CALLBACK JsSetBreakOnException(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    int breakOnExceptionAttributes;
+    bool success = false;
+
+    if (argumentCount > 1 && jsrt::ValueToInt(arguments[1],
+      &breakOnExceptionAttributes) == JsNoError &&
+      JsDiagSetBreakOnException(
+        jsrt::IsolateShim::GetCurrent()->GetRuntimeHandle(),
+        (JsDiagBreakOnExceptionAttributes)breakOnExceptionAttributes) ==
+      JsNoError) {
+      success = true;
+    }
+
+    JsValueRef returnRef;
+    JsBoolToBoolean(success, &returnRef);
+
+    return returnRef;
+  }
+
+  static JsValueRef CALLBACK JsGetBreakOnException(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *arguments,
+    unsigned short argumentCount,
+    void *callbackState) {
+    JsDiagBreakOnExceptionAttributes breakOnExceptionAttributes =
+      JsDiagBreakOnExceptionAttributeNone;
+
+    JsErrorCode errorCode = JsDiagGetBreakOnException(
+      jsrt::IsolateShim::GetCurrent()->GetRuntimeHandle(),
+      &breakOnExceptionAttributes);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef returnRef = JS_INVALID_REFERENCE;
+    errorCode = JsIntToNumber(breakOnExceptionAttributes, &returnRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    return returnRef;
+  }
+
+  bool Debugger::IsDebugEnabled() {
+    return v8::g_EnableDebug;
+  }
+
+  void Debugger::StartDebugging(JsRuntimeHandle runtime) {
+    JsErrorCode errorCode = JsDiagStartDebugging(
+      runtime, JsDiagDebugEventHandler, nullptr);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+  }
+
+  void Debugger::InstallHostCallback(JsValueRef chakraDebugObject,
+    const wchar_t *name, JsNativeFunction nativeFunction) {
+    JsValueRef nameVar;
+    JsErrorCode errorCode = JsPointerToString(name, wcslen(name), &nameVar);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef funcRef;
+    errorCode = JsCreateNamedFunction(
+      nameVar, nativeFunction, nullptr, &funcRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsPropertyIdRef propertyIdRef;
+    errorCode = JsGetPropertyIdFromName(name, &propertyIdRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    errorCode = JsSetProperty(chakraDebugObject, propertyIdRef, funcRef, true);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+  }
+
+  void Debugger::SetChakraDebugObject(JsValueRef chakraDebugObject) {
+    JsPropertyIdRef propertyIdRef;
+
+    JsErrorCode errorCode = JsGetPropertyIdFromName(
+      L"ProcessDebuggerMessage", &propertyIdRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef processDebuggerMessageFn;
+    errorCode = JsGetProperty(chakraDebugObject,
+      propertyIdRef, &processDebuggerMessageFn);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    errorCode = JsGetPropertyIdFromName(L"ProcessDebugEvent",
+      &propertyIdRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef processDebugEventFn;
+    errorCode = JsGetProperty(chakraDebugObject,
+      propertyIdRef, &processDebugEventFn);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    errorCode = JsGetPropertyIdFromName(L"ProcessShouldContinue",
+      &propertyIdRef);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    JsValueRef processShouldContinueFn;
+    errorCode = JsGetProperty(chakraDebugObject,
+      propertyIdRef, &processShouldContinueFn);
+    CHAKRA_VERIFY_NOERROR(errorCode);
+
+    Debugger::messageQueue.SetProcessMessageFunctions(chakraDebugObject,
+      processDebuggerMessageFn, processDebugEventFn, processShouldContinueFn);
+
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"log", Log);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetScripts", JsGetScripts);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetSource", JsGetSource);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagSetStepType", JsSetStepType);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagSetBreakpoint", JsSetBreakpoint);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetFunctionPosition", JsGetFunctionPosition);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetStackTrace", JsGetStackTrace);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetStackProperties", JsGetStackProperties);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetObjectFromHandle", JsGetObjectFromHandle);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagEvaluateScript", JsEvaluateScript);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagEvaluate", JsEvaluate);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetBreakpoints", JsGetBreakpoints);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetProperties", JsGetProperties);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagRemoveBreakpoint", JsRemoveBreakpoint);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagSetBreakOnException", JsSetBreakOnException);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"JsDiagGetBreakOnException", JsGetBreakOnException);
+    Debugger::InstallHostCallback(chakraDebugObject,
+      L"SendDelayedRespose", SendDelayedRespose);
+  }
+
+}  // namespace jsrt

--- a/deps/chakrashim/src/jsrtdebug.h
+++ b/deps/chakrashim/src/jsrtdebug.h
@@ -1,0 +1,85 @@
+// Copyright Microsoft. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and / or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#pragma once
+
+#include <queue>
+#include "uv.h"
+#include "v8-debug.h"
+
+namespace jsrt {
+class MessageImpl : public v8::Debug::Message {
+ public:
+  explicit MessageImpl(v8::Local<v8::String> v8Str);
+  virtual v8::Local<v8::String> GetJSON() const;
+  virtual v8::Isolate* GetIsolate() const;
+  static v8::Local<v8::String> JsValueRefToV8String(JsValueRef result);
+
+ private:
+  v8::Local<v8::String> v8Str;
+};
+
+class MessageQueue {
+ public:
+  MessageQueue();
+  ~MessageQueue();
+  void SaveMessage(const uint16_t* command, int length);
+  uint16_t* PopMessage();
+  void SetProcessMessageFunctions(
+    JsValueRef chakraDebugObject,
+    JsValueRef processDebuggerMessageFn,
+    JsValueRef processDebugEventFn,
+    JsValueRef processShouldContinueFn);
+  void ProcessDebuggerMessage();
+  void ProcessDebugEvent(
+    JsDiagDebugEvent debugEvent,
+    JsValueRef eventData);
+  bool ShouldContinue(JsDiagDebugEvent debugEvent);
+  bool IsEmpty();
+  void WaitForMessage();
+  bool waitingForMessage;
+  bool isProcessingDebuggerMsg;
+  int debugEventProcessCount;
+
+ private:
+  std::queue<uint16_t*> *msgQueue;
+  JsValueRef chakraDebugObject;
+  JsValueRef processDebuggerMessageFn;
+  JsValueRef processDebugEventFn;
+  JsValueRef processShouldContinueFn;
+  uv_sem_t newMsgSem;
+  uv_cond_t cond;
+  uv_mutex_t mutex;
+  uv_mutex_t msgMutex;
+};
+
+class Debugger {
+ public:
+  static MessageQueue messageQueue;
+  static v8::Debug::MessageHandler handler;
+  static bool IsDebugEnabled();
+  static void StartDebugging(JsRuntimeHandle runtime);
+  static void SetChakraDebugObject(JsValueRef chakraDebugObject);
+ private:
+  static void InstallHostCallback(JsValueRef chakraDebugObject,
+    const wchar_t *name,
+    JsNativeFunction nativeFunction);
+};
+}  // namespace jsrt

--- a/deps/chakrashim/src/jsrtisolateshim.cc
+++ b/deps/chakrashim/src/jsrtisolateshim.cc
@@ -23,6 +23,8 @@
 #include <assert.h>
 #include <vector>
 #include <algorithm>
+#include "v8-debug.h"
+#include "jsrtdebug.h"
 
 namespace v8 {
 extern bool g_disableIdleGc;
@@ -30,6 +32,7 @@ extern bool g_disableIdleGc;
 namespace jsrt {
 
 /* static */ __declspec(thread) IsolateShim * IsolateShim::s_currentIsolate;
+/* static */ __declspec(thread) IsolateShim * IsolateShim::s_previousIsolate;
 /* static */ IsolateShim * IsolateShim::s_isolateList = nullptr;
 
 IsolateShim::IsolateShim(JsRuntimeHandle runtime)
@@ -39,7 +42,9 @@ IsolateShim::IsolateShim(JsRuntimeHandle runtime)
       cachedPropertyIdRefs(),
       embeddedData(),
       isDisposing(false),
-      tryCatchStackTop(nullptr) {
+      tryCatchStackTop(nullptr),
+      arrayBufferAllocator(nullptr),
+      debugContext(nullptr) {
   // CHAKRA-TODO: multithread locking for s_isolateList?
   this->prevnext = &s_isolateList;
   this->next = s_isolateList;
@@ -59,12 +64,6 @@ IsolateShim::~IsolateShim() {
 }
 
 /* static */ v8::Isolate * IsolateShim::New() {
-  // CHAKRA-TODO: Disable multiple isolate for now until it is fully implemented
-  if (s_isolateList != nullptr) {
-    CHAKRA_UNIMPLEMENTED_("multiple isolate");
-    return nullptr;
-  }
-
   bool disableIdleGc = v8::g_disableIdleGc;
   JsRuntimeHandle runtime;
   JsErrorCode error =
@@ -77,12 +76,21 @@ IsolateShim::~IsolateShim() {
     return nullptr;
   }
 
+  if (jsrt::Debugger::IsDebugEnabled()) {
+    // If JavaScript debugging APIs need to be exposed then
+    // runtime should be in debugging mode from start
+    jsrt::Debugger::StartDebugging(runtime);
+  }
+
   IsolateShim* newIsolateshim = new IsolateShim(runtime);
   if (!disableIdleGc) {
     uv_prepare_init(uv_default_loop(), newIsolateshim->idleGc_prepare_handle());
-    uv_unref(reinterpret_cast<uv_handle_t*>(newIsolateshim->idleGc_prepare_handle()));
-    uv_timer_init(uv_default_loop(), newIsolateshim->idleGc_timer_handle());
-    uv_unref(reinterpret_cast<uv_handle_t*>(newIsolateshim->idleGc_timer_handle()));
+    uv_unref(reinterpret_cast<uv_handle_t*>(
+      newIsolateshim->idleGc_prepare_handle()));
+    uv_timer_init(uv_default_loop(),
+      newIsolateshim->idleGc_timer_handle());
+    uv_unref(reinterpret_cast<uv_handle_t*>(
+      newIsolateshim->idleGc_timer_handle()));
   }
   return ToIsolate(newIsolateshim);
 }
@@ -108,7 +116,8 @@ IsolateShim::~IsolateShim() {
 void IsolateShim::Enter() {
   // CHAKRA-TODO: we don't support multiple isolate currently, this also doesn't
   // support reentrence
-  assert(s_currentIsolate == nullptr);
+  assert(s_currentIsolate == nullptr || s_currentIsolate == this);
+  s_previousIsolate = s_currentIsolate;
   s_currentIsolate = this;
 }
 
@@ -116,7 +125,8 @@ void IsolateShim::Exit() {
   // CHAKRA-TODO: we don't support multiple isolate currently, this also doesn't
   // support reentrence
   assert(s_currentIsolate == this);
-  s_currentIsolate = nullptr;
+  s_currentIsolate = s_previousIsolate;
+  s_previousIsolate = nullptr;
 }
 
 JsRuntimeHandle IsolateShim::GetRuntimeHandle() {

--- a/deps/chakrashim/src/jsrtisolateshim.h
+++ b/deps/chakrashim/src/jsrtisolateshim.h
@@ -45,7 +45,7 @@ enum CachedSymbolPropertyIdRef {
 
 class IsolateShim {
  public:
-
+  v8::ArrayBuffer::Allocator* arrayBufferAllocator;
   bool IsolateShim::NewContext(JsContextRef * context, bool exposeGC,
                                JsValueRef globalObjectTemplateInstance);
   bool GetMemoryUsage(size_t * memoryUsage);
@@ -100,6 +100,8 @@ class IsolateShim {
 
   void SetData(unsigned int slot, void* data);
   void* GetData(unsigned int slot);
+
+  ContextShim* debugContext;
 
   inline uv_prepare_t* idleGc_prepare_handle() {
     return &idleGc_prepare_handle_;
@@ -161,6 +163,7 @@ class IsolateShim {
   static IsolateShim * s_isolateList;
 
   static __declspec(thread) IsolateShim * s_currentIsolate;
+  static __declspec(thread) IsolateShim * s_previousIsolate;
 
   uv_prepare_t idleGc_prepare_handle_;
   uv_timer_t idleGc_timer_handle_;

--- a/deps/chakrashim/src/jsrtutils.h
+++ b/deps/chakrashim/src/jsrtutils.h
@@ -54,6 +54,9 @@
 #define CHAKRA_VERIFY(expr) if (!(expr)) { \
   jsrt::Fatal("internal error %s(%d): %s", __FILE__, __LINE__, #expr); }
 
+#define CHAKRA_VERIFY_NOERROR(errorCode) if (errorCode != JsNoError) { \
+  jsrt::Fatal("internal error %s(%d): %x", __FILE__, __LINE__, errorCode); }
+
 #ifdef DEBUG
 #define CHAKRA_ASSERT(expr) assert(expr)
 #else

--- a/deps/chakrashim/src/v8arraybuffer.cc
+++ b/deps/chakrashim/src/v8arraybuffer.cc
@@ -57,7 +57,8 @@ Local<ArrayBuffer> ArrayBuffer::New(Isolate* isolate,
   ArrayBufferFinalizeInfo* callbackState = nullptr;
 
   if (mode == ArrayBufferCreationMode::kInternalized) {
-      ArrayBufferFinalizeInfo info = { g_arrayBufferAllocator,
+      ArrayBufferFinalizeInfo info = {
+          jsrt::IsolateShim::FromIsolate(isolate)->arrayBufferAllocator,
                                        data,
                                        byte_length };
       finalizeCallback = ExternalArrayBufferFinalizeCallback;

--- a/deps/chakrashim/src/v8chakra.h
+++ b/deps/chakrashim/src/v8chakra.h
@@ -27,9 +27,6 @@ namespace v8 {
 using jsrt::ContextShim;
 class ObjectTemplateData;
 
-extern __declspec(thread) bool g_EnableDebug;
-extern ArrayBuffer::Allocator* g_arrayBufferAllocator;
-
 // External object data types
 enum class ExternalDataTypes {
   Unknown,

--- a/deps/chakrashim/src/v8debug.cc
+++ b/deps/chakrashim/src/v8debug.cc
@@ -18,74 +18,64 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#include "v8.h"
-#include "v8-debug.h"
 #include "jsrtutils.h"
+#include "jsrtdebug.h"
 
 namespace v8 {
 
-__declspec(thread) bool g_EnableDebug = false;
-static JsContextRef g_debugContext = JS_INVALID_REFERENCE;
+  __declspec(thread) bool g_EnableDebug = false;
 
-bool Debug::EnableAgent(const char *name, int port, bool wait_for_connection) {
-  HRESULT hr = S_OK;
-
-#ifndef NODE_ENGINE_CHAKRACORE
-  if (!g_EnableDebug) {
-    // JsStartDebugging needs COM initialization
-    IfComFailError(CoInitializeEx(nullptr, COINIT_MULTITHREADED));
-
+  void Debug::EnableDebug() {
     g_EnableDebug = true;
-
-    Local<Context> currentContext = Context::GetCurrent();
-    if (!currentContext.IsEmpty()) {
-      // Turn on debug mode on current Context (script engine), which was
-      // created before start debugging and not in debug mode.
-      JsStartDebugging();
-    }
   }
 
-error:
-#else
-  hr = E_FAIL;  // ChakraCore does not support JsStartDebugging
-#endif
+  Local<Context> Debug::GetDebugContext(Isolate* isolate) {
+    jsrt::IsolateShim* isoShim = jsrt::IsolateShim::FromIsolate(isolate);
+    JsContextRef debugContextRef = JS_INVALID_REFERENCE;
+    if (isoShim->debugContext == JS_INVALID_REFERENCE) {
+      HandleScope scope(isolate);
+      debugContextRef = *Context::New(isolate);
+      isoShim->debugContext = isoShim->GetContextShim(
+        debugContextRef);
+      JsAddRef(debugContextRef, nullptr);
 
-  return SUCCEEDED(hr);
-}
+      Local<Object> global = Context::GetCurrent()->Global();
 
-bool Debug::IsAgentEnabled() {
-  return g_EnableDebug;
-}
-
-Local<Context> Debug::GetDebugContext(Isolate* isolate) {
-  if (g_debugContext == JS_INVALID_REFERENCE) {
-    HandleScope scope(isolate);
-    g_debugContext = *Context::New(isolate);
-    JsAddRef(g_debugContext, nullptr);
-
-    Local<Object> global = Context::GetCurrent()->Global();
-
-    // CHAKRA-TODO: Chakra doesn't fully implement the debugger without
-    // --debug flag. Add a dummy 'Debug' on global object if it doesn't
-    // already exist.
-    {
-      Context::Scope context_scope(g_debugContext);
-      jsrt::ContextShim* contextShim = jsrt::ContextShim::GetCurrent();
-      JsValueRef ensureDebug = contextShim->GetensureDebugFunction();
-      JsValueRef unused;
-      if (jsrt::CallFunction(ensureDebug, *global, &unused) != JsNoError) {
-        return Local<Context>();
+      // CHAKRA-TODO: Chakra doesn't fully implement the debugger without
+      // --debug flag. Add a dummy 'Debug' on global object if it doesn't
+      // already exist.
+      {
+        Context::Scope context_scope(debugContextRef);
+        jsrt::ContextShim* contextShim = jsrt::ContextShim::GetCurrent();
+        JsValueRef ensureDebug = contextShim->GetensureDebugFunction();
+        JsValueRef unused;
+        if (jsrt::CallFunction(ensureDebug, *global, &unused) != JsNoError) {
+          return Local<Context>();
+        }
       }
     }
+
+    return static_cast<Context*>(isoShim->debugContext->GetContextRef());
   }
 
-  return static_cast<Context*>(g_debugContext);
-}
+  void Debug::SendCommand(Isolate* isolate,
+    const uint16_t* command, int length,
+    ClientData* client_data) {
+    CHAKRA_ASSERT(client_data == NULL);
 
-void Debug::Dispose() {
-  if (g_EnableDebug) {
-    CoUninitialize();
+    // Save command in a queue and when JsDiagDebugEventHandler
+    // is called we need to process the queue
+    jsrt::Debugger::messageQueue.SaveMessage(command, length);
+
+    // Request async break from engine so that we can process
+    // commands on JsDiagDebugEventAsyncBreak
+    JsErrorCode errorCode = JsDiagRequestAsyncBreak(
+      jsrt::IsolateShim::FromIsolate(isolate)->GetRuntimeHandle());
+    CHAKRA_VERIFY_NOERROR(errorCode);
   }
-}
+
+  void Debug::SetMessageHandler(Isolate* isolate, MessageHandler handler) {
+    jsrt::Debugger::handler = handler;
+  }
 
 }  // namespace v8

--- a/deps/chakrashim/src/v8isolate.cc
+++ b/deps/chakrashim/src/v8isolate.cc
@@ -30,7 +30,9 @@ CpuProfiler dummyCpuProfiler;
 Isolate* Isolate::New(const CreateParams& params) {
   Isolate* iso = jsrt::IsolateShim::New();
   if (params.array_buffer_allocator) {
-    V8::SetArrayBufferAllocator(params.array_buffer_allocator);
+    CHAKRA_VERIFY(!jsrt::IsolateShim::FromIsolate(iso)->arrayBufferAllocator);
+    jsrt::IsolateShim::FromIsolate(iso)->arrayBufferAllocator =
+        params.array_buffer_allocator;
   }
   return iso;
 }

--- a/deps/chakrashim/src/v8v8.cc
+++ b/deps/chakrashim/src/v8v8.cc
@@ -30,7 +30,7 @@ bool g_disposed = false;
 bool g_exposeGC = false;
 bool g_useStrict = false;
 bool g_disableIdleGc = false;
-ArrayBuffer::Allocator* g_arrayBufferAllocator = nullptr;
+bool g_trace_debug_json = false;
 
 const char *V8::GetVersion() {
   static char versionStr[32] = {};
@@ -106,11 +106,18 @@ void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
       if (remove_flags) {
         argv[i] = nullptr;
       }
+    } else if (equals("--trace-debug-json", arg) ||
+      equals("--trace_debug_json", arg)) {
+      g_trace_debug_json = true;
+      if (remove_flags) {
+        argv[i] = nullptr;
+      }
     } else if (remove_flags &&
                (startsWith(
                  arg, "--debug")  // Ignore some flags to reduce unit test noise
                 || startsWith(arg, "--harmony")
-                || startsWith(arg, "--stack-size="))) {
+                || startsWith(arg, "--stack-size=")
+                || startsWith(arg, "--nolazy"))) {
       argv[i] = nullptr;
     } else if (equals("--help", arg)) {
         char* helpText =
@@ -140,21 +147,12 @@ bool V8::Initialize() {
   if (g_disposed) {
     return false;  // Can no longer Initialize if Disposed
   }
-#ifndef NODE_ENGINE_CHAKRACORE
-  if (g_EnableDebug && JsStartDebugging() != JsNoError) {
-    return false;
-  }
-#endif
+
   return true;
 }
 
 void V8::SetEntropySource(EntropySource entropy_source) {
   // CHAKRA-TODO
-}
-
-void V8::SetArrayBufferAllocator(ArrayBuffer::Allocator* allocator) {
-  CHAKRA_VERIFY(!g_arrayBufferAllocator);
-  g_arrayBufferAllocator = allocator;
 }
 
 bool V8::IsDead() {
@@ -164,7 +162,6 @@ bool V8::IsDead() {
 bool V8::Dispose() {
   g_disposed = true;
   jsrt::IsolateShim::DisposeAll();
-  Debug::Dispose();
   return true;
 }
 

--- a/src/debug-agent.cc
+++ b/src/debug-agent.cc
@@ -163,11 +163,18 @@ void Agent::WorkerRun() {
     Isolate::Scope isolate_scope(isolate);
 
     HandleScope handle_scope(isolate);
+#ifndef NODE_ENGINE_CHAKRACORE
     IsolateData isolate_data(isolate, &child_loop_,
                              array_buffer_allocator.zero_fill_field());
+#endif
     Local<Context> context = Context::New(isolate);
 
     Context::Scope context_scope(context);
+    // CHAKRA-TODO : fix this to create isolate_data before setting context
+#ifdef NODE_ENGINE_CHAKRACORE
+    IsolateData isolate_data(isolate, &child_loop_,
+        array_buffer_allocator.zero_fill_field());
+#endif
     Environment env(&isolate_data, context);
 
     const bool start_profiler_idle_notifier = false;

--- a/src/node.cc
+++ b/src/node.cc
@@ -3781,13 +3781,8 @@ static void StartDebug(Environment* env, const char* path, bool wait) {
     env->debugger_agent()->set_dispatch_handler(
           DispatchMessagesDebugAgentCallback);
     const char* host = debug_host ? debug_host->c_str() : "127.0.0.1";
-#if defined(NODE_ENGINE_CHAKRACORE)
-  // ChakraShim does not support debugger_agent
-  debugger_running = v8::Debug::EnableAgent();
-#else
   debugger_running =
         env->debugger_agent()->Start(host, debug_port, wait);
-#endif
     if (debugger_running == false) {
       fprintf(stderr, "Starting debugger on %s:%d failed\n", host, debug_port);
       fflush(stderr);
@@ -4249,6 +4244,13 @@ void Init(int* argc,
   if (v8_argc > 1) {
     exit(9);
   }
+
+  // CHAKRA-TODO : fix this to not do it here
+#ifdef NODE_ENGINE_CHAKRACORE
+  if (use_debug_agent) {
+      v8::Debug::EnableDebug();
+  }
+#endif
 
   // Unconditionally force typed arrays to allocate outside the v8 heap. This
   // is to prevent memory pointers from being moved around that are returned by


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change

<!-- provide a description of the change below this comment -->

This change adds JavaScript debugging support in node-chakracore by using
JsRT debugging apis added in chakracore release 1.3. A shim convert v8
debugging protocol messages to chakracore debugging apis and visa-versa.

node-chakracore only expose the debugging protocol messages and doesn't
shim all the apis which v8 provides, so it is only debuggable using tools
which just relies on debugging protocol json and doesn't use internals
of v8 debugging implementations.

PR-URL: nodejs/node-chakracore#126
Reviewed-By: Hitesh Kanwathirtha <hiteshk@microsoft.com>
Reviewed-By: Jianchun Xu <Jianchun.Xu@microsoft.com>
Reviewed-By: Kunal Pathak <Kunal.Pathak@microsoft.com>
Reviewed-By: Oguz Bastemur <ogbastem@microsoft.com>